### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/demo-server-up.yml
+++ b/.github/workflows/demo-server-up.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Publish SSR image to Registry
         id: ssr
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           serviceWorker: false
           displayVersion: ${{ github.event.after }}
@@ -45,7 +45,7 @@ jobs:
           buildargs: serviceWorker,displayVersion,testing
       - name: Publish NGINX image to Registry
         id: nginx
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: intershop-pwa-nginx
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Publish Reports Image to Registry
         id: reports
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: reports
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore